### PR TITLE
Querystring parsing bug when creating authenticated URI

### DIFF
--- a/lib/D2L.Extensibility.AuthSdk.UnitTests/FunctionalApiUriTests.cs
+++ b/lib/D2L.Extensibility.AuthSdk.UnitTests/FunctionalApiUriTests.cs
@@ -298,7 +298,7 @@ namespace D2L.Extensibility.AuthSdk.UnitTests {
 		}
 
 		[Test]
-		public void UserContext_CreateAuthUri_MultipleQuerystringsAreNotPresent() {
+		public void UserContext_CreateAuthUri_MultipleQuerystringSegmentsAreNotPresent() {
 			const string querystringCharacterEncoded = "%3F";
 
 			Uri queryUrl = m_userContext.CreateAuthenticatedUri( TestConstants.API_PATH_WITH_QUERY, "GET" );

--- a/lib/D2L.Extensibility.AuthSdk.UnitTests/FunctionalApiUriTests.cs
+++ b/lib/D2L.Extensibility.AuthSdk.UnitTests/FunctionalApiUriTests.cs
@@ -288,6 +288,32 @@ namespace D2L.Extensibility.AuthSdk.UnitTests {
 		}
 
 		[Test]
+		public void UserContext_CreateAuthUri_QuerystringIsMaintained() {
+			Uri queryUrl = m_userContext.CreateAuthenticatedUri( TestConstants.API_PATH_WITH_QUERY, "GET" );
+
+			Assert.IsTrue(
+				queryUrl.ToString().Contains( TestConstants.API_PATH_QUERYSTRING ),
+				"The querystring parameter was not present"
+				);
+		}
+
+		[Test]
+		public void UserContext_CreateAuthUri_MultipleQuerystringsAreNotPresent() {
+			const string querystringCharacterEncoded = "%3F";
+
+			Uri queryUrl = m_userContext.CreateAuthenticatedUri( TestConstants.API_PATH_WITH_QUERY, "GET" );
+			bool duplicatedQuery = (
+				queryUrl.ToString().Contains( "?" ) &&
+				queryUrl.ToString().Contains( querystringCharacterEncoded )
+				);
+
+			Assert.IsFalse(
+				duplicatedQuery,
+				"Both the querystring character and the encoded querystring character are present."
+				);
+		}
+
+		[Test]
 		public void UserContext_CreateAuthUri_IfThereIsClockSkew_SignatureUsesAdjustedTimestamp() {
 			const string httpMethod = "POST";
 			const long serverClockSkewMilliseconds = 343000;

--- a/lib/D2L.Extensibility.AuthSdk.UnitTests/FunctionalApiUriTests.cs
+++ b/lib/D2L.Extensibility.AuthSdk.UnitTests/FunctionalApiUriTests.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.Text;
+using System.Web;
 using NUnit.Framework;
 using System.Globalization;
 
@@ -288,7 +290,7 @@ namespace D2L.Extensibility.AuthSdk.UnitTests {
 		}
 
 		[Test]
-		public void UserContext_CreateAuthUri_QuerystringIsMaintained() {
+		public void UserContext_CreateAuthUri_PathQuerystringIsPresent() {
 			Uri queryUrl = m_userContext.CreateAuthenticatedUri( TestConstants.API_PATH_WITH_QUERY, "GET" );
 
 			Assert.IsTrue(
@@ -298,10 +300,19 @@ namespace D2L.Extensibility.AuthSdk.UnitTests {
 		}
 
 		[Test]
+		public void UserContext_CreateAuthUri_PathQuerystringIsMerged() {
+			Uri queryUrl = m_userContext.CreateAuthenticatedUri( TestConstants.API_PATH_WITH_QUERY, "GET" );
+			NameValueCollection query = HttpUtility.ParseQueryString( queryUrl.Query );
+
+			Assert.AreEqual( "baz", query["bar"], "The path querystring is not present." );
+			Assert.IsNotNullOrEmpty( query["x_a"], "The first Valence querystring parameter is not present." );
+		}
+
+		[Test]
 		public void UserContext_CreateAuthUri_MultipleQuerystringSegmentsAreNotPresent() {
 			const string querystringCharacterEncoded = "%3F";
-
 			Uri queryUrl = m_userContext.CreateAuthenticatedUri( TestConstants.API_PATH_WITH_QUERY, "GET" );
+
 			bool duplicatedQuery = (
 				queryUrl.ToString().Contains( "?" ) &&
 				queryUrl.ToString().Contains( querystringCharacterEncoded )

--- a/lib/D2L.Extensibility.AuthSdk.UnitTests/TestConstants.cs
+++ b/lib/D2L.Extensibility.AuthSdk.UnitTests/TestConstants.cs
@@ -11,8 +11,8 @@ namespace D2L.Extensibility.AuthSdk.UnitTests {
 		public const string API_URL = "http://univ.edu/d2l/api/lp/1.0/organization/info";
 		public const string ESCAPED_CALLBACK = "http://sample/abc%20xyz/?test=foo+bar&magic=true";
 		public const string API_PATH = "/d2l/api/lp/1.0/organization/info";
-		public const string API_PATH_WITH_QUERY = "/d2l/api/lp/1.0/organization/info?query=somequery";
-		public const string API_PATH_QUERYSTRING = "query=somequery";
+		public const string API_PATH_WITH_QUERY = "/foo?bar=baz";
+		public const string API_PATH_QUERYSTRING = "bar=baz";
 		public const long TIMESTAMP_MILLISECONDS = 1234567890L;
 		public const long TIMESTAMP_SECONDS = 1234567L;
 	}

--- a/lib/D2L.Extensibility.AuthSdk.UnitTests/TestConstants.cs
+++ b/lib/D2L.Extensibility.AuthSdk.UnitTests/TestConstants.cs
@@ -11,6 +11,8 @@ namespace D2L.Extensibility.AuthSdk.UnitTests {
 		public const string API_URL = "http://univ.edu/d2l/api/lp/1.0/organization/info";
 		public const string ESCAPED_CALLBACK = "http://sample/abc%20xyz/?test=foo+bar&magic=true";
 		public const string API_PATH = "/d2l/api/lp/1.0/organization/info";
+		public const string API_PATH_WITH_QUERY = "/d2l/api/lp/1.0/organization/info?query=somequery";
+		public const string API_PATH_QUERYSTRING = "query=somequery";
 		public const long TIMESTAMP_MILLISECONDS = 1234567890L;
 		public const long TIMESTAMP_SECONDS = 1234567L;
 	}

--- a/lib/D2L.Extensibility.AuthSdk/Impl/D2LUserContext.cs
+++ b/lib/D2L.Extensibility.AuthSdk/Impl/D2LUserContext.cs
@@ -17,10 +17,18 @@ namespace D2L.Extensibility.AuthSdk.Impl {
         }
 
         private Uri CreateApiUrl(string path) {
-
+			
             var builder = m_apiHost.ToUriBuilder();
-            builder.Path = path;
-            return builder.Uri;
+
+	        if( !path.Contains( "?" ) ) {
+		        builder.Path = path;
+	        } else {
+		        string[] pathParts = path.Split( new[] {'?'}, 2 );
+		        builder.Path = pathParts[0];
+		        builder.Query = pathParts[1];
+	        }
+
+			return builder.Uri;
         }
 
         public Uri CreateAuthenticatedUri(string path, string httpMethod) {

--- a/lib/D2L.Extensibility.AuthSdk/Impl/D2LUserContext.cs
+++ b/lib/D2L.Extensibility.AuthSdk/Impl/D2LUserContext.cs
@@ -17,18 +17,18 @@ namespace D2L.Extensibility.AuthSdk.Impl {
         }
 
         private Uri CreateApiUrl(string path) {
-			
+
             var builder = m_apiHost.ToUriBuilder();
 
-	        if( !path.Contains( "?" ) ) {
-		        builder.Path = path;
-	        } else {
-		        string[] pathParts = path.Split( new[] {'?'}, 2 );
-		        builder.Path = pathParts[0];
-		        builder.Query = pathParts[1];
-	        }
+            if( !path.Contains( "?" ) ) {
+                builder.Path = path;
+            } else {
+                string[] pathParts = path.Split( new[] {'?'}, 2 );
+                builder.Path = pathParts[0];
+                builder.Query = pathParts[1];
+            }
 
-			return builder.Uri;
+            return builder.Uri;
         }
 
         public Uri CreateAuthenticatedUri(string path, string httpMethod) {

--- a/lib/GlobalAssemblyInfo.cs
+++ b/lib/GlobalAssemblyInfo.cs
@@ -8,9 +8,9 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle( "D2L Extensibility Client-Side Library for .NET" )]
 [assembly: AssemblyDescription( "D2L Extensibility Client-Side Library for .NET" )]
 [assembly: AssemblyConfiguration( "" )]
-[assembly: AssemblyCompany( "Desire2Learn, Inc." )]
+[assembly: AssemblyCompany( "D2L Corporation" )]
 [assembly: AssemblyProduct( "D2L Extensibility Client-Side Library for .NET" )]
-[assembly: AssemblyCopyright( "Copyright © Desire2Learn Inc. 2011-2013" )]
+[assembly: AssemblyCopyright( "Copyright © Desire2Learn Inc. 2011-2015" )]
 [assembly: AssemblyTrademark( "" )]
 [assembly: AssemblyCulture( "" )]
 
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion( "1.1.0.0" )]
-[assembly: AssemblyFileVersion( "1.1.0.0" )]
+[assembly: AssemblyVersion( "1.1.1.0" )]
+[assembly: AssemblyFileVersion( "1.1.1.0" )]


### PR DESCRIPTION
In the current version of the Valence C# SDK, if a path/route is given to the CreateAuthenticatedUri(string, string) method in the D2LUserContext class that contains a querystring, the querystring will be encoded and treated as part of the path.

This PR fixes that behaviour and adds tests to check for potential future regressions.